### PR TITLE
allow `=return` to use data from html attributes

### DIFF
--- a/lib/mast.js
+++ b/lib/mast.js
@@ -143,6 +143,8 @@ function handleReturnAttr(event, target, returnAttrVals) {
                     return;
                 };
                 returnData[returnAttr] = String(returnObj.dataset[dataKey]);
+            } else if (target.hasAttribute(key)) {
+                returnData[returnAttr] = target.getAttribute(key)
             } else {
                 if (!(key in returnObj)) {
                     console.error(`Property: ${key} does not exist on the specified object`);

--- a/mar/js.hoon
+++ b/mar/js.hoon
@@ -15,6 +15,7 @@
                 ==
     ++  html    ;html:(head:"{script}" body)
     --
+  ++  txt  (to-wain:format (@t mud))
   --
 ++  grab
   |%                                                    ::  convert from

--- a/mar/mime.hoon
+++ b/mar/mime.hoon
@@ -1,0 +1,32 @@
+::
+::::  /hoon/mime/mar
+  ::
+/?    310
+::
+|_  own=mime
+++  grow
+  ^?
+  |%
+  ++  jam  `@`q.q.own
+  --
+::
+++  grab                                                ::  convert from
+  ^?
+  |%
+  ++  noun  mime                                  ::  clam from %noun
+  ++  tape
+    |=(a=_"" [/application/x-urb-unknown (as-octt:mimes:html a)])
+  --
+++  grad
+  ^?
+  |%
+  ++  form  %mime
+  ++  diff  |=(mime +<)
+  ++  pact  |=(mime +<)
+  ++  join  |=([mime mime] `(unit mime)`~)
+  ++  mash
+    |=  [[ship desk mime] [ship desk mime]]
+    ^-  mime
+    ~|(%mime-mash !!)
+  --
+--


### PR DESCRIPTION
this PR has 2 commits.

the first is trivial: adding the mime mark and fixing the js mark.

the second commit allows this pattern to work:

```
;button
  =sound  "beep"
  =return  "/target/sound"
  =event  "/click/honk"
  ; horn
==
```