### PR TITLE
handle client attributes once per diff

### DIFF
--- a/lib/mast.js
+++ b/lib/mast.js
@@ -260,7 +260,6 @@ function handleDiff(diff) {
                 if (newNode.nodeType === 1) {
                     handleListeners(newNode);
                     handleClientStateElements(newNode);
-                    handleClientAttrs(newNode);
                 };
                 break;
             case 'm':
@@ -304,6 +303,7 @@ function handleDiff(diff) {
                 break;
         };
     });
+    handleClientAttrs(document.body)
 };
 function sendActions(actArray) {
     fetch(channelPath, {


### PR DESCRIPTION
we were running into a problem where even though `handleClientStateElements` would update the clientState map, the UI wouldn't change.

this fixed that by searching the whole document.body for client-* attributes and updating once per diff.